### PR TITLE
Creates the storybook resources and deploys storybook to s3

### DIFF
--- a/.aws/environments/non-prod/ucurtma-app-bucket.tf
+++ b/.aws/environments/non-prod/ucurtma-app-bucket.tf
@@ -6,10 +6,11 @@ module "non-prod-app-deployment" {
   web_page_user = "deployment-user"
 }
 
-variable "remote_state" {
-  default = {
-    bucket = "ucurtma-app-state"
-    key    = "terraform/dev/terraform_dev.tfstate"
-    region = "eu-west-2"
-  }
+module "non-prod-app-static-deployment" {
+  source       = "../../modules/s3/web_hosting_s3_bucket"
+  bucket       = "non-prod.ucurtmaprojesi.com"
+  region       = "eu-west-2"
+  remote_state = "${var.remote_state}"
+  web_page_user = "non-prod-static-app-deployment-user"
 }
+

--- a/.aws/environments/non-prod/ucurtma-storybook-bucket.tf
+++ b/.aws/environments/non-prod/ucurtma-storybook-bucket.tf
@@ -1,0 +1,8 @@
+module "non-prod-app-storybook-deployment" {
+  source        = "../../modules/s3/web_hosting_s3_bucket"
+  bucket        = "components.ucurtmaprojesi.com"
+  region        = "eu-west-2"
+  remote_state  = "${var.remote_state}"
+  web_page_user = "non-prod-storybook-deployment-user"
+}
+

--- a/.aws/environments/non-prod/variables_inputs.tf
+++ b/.aws/environments/non-prod/variables_inputs.tf
@@ -1,0 +1,7 @@
+variable "remote_state" {
+  default = {
+    bucket = "ucurtma-app-state"
+    key    = "terraform/dev/terraform_dev.tfstate"
+    region = "eu-west-2"
+  }
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,19 @@ references:
   deploy_to_non_prod: &deploy_to_non_prod
     run:
       name: Deploy to AWS non-prod bucket
-      command: aws s3 sync ./packages/frontend/out/ s3://non-prod-ucurtma-app --delete
+      command: aws s3 sync ./packages/frontend/out/ s3://non-prod.ucurtmaprojesi.com --delete
   build_static_bundle: &build_static_bundle
     run:
       name: Export the application bundle
       command: yarn build && yarn export
+  build_storybook: &build_storybook
+    run:
+      name: Build storybook components
+      command: yarn build:storybook
+  deploy_storybook_to_s3: &deploy_storybook_to_s3
+    run:
+      name: Deploy storybook to AWS
+      command: aws s3 sync ./packages/frontend/storybook-static/ s3://components.ucurtmaprojesi.com --delete
 jobs:
   build:
     docker:
@@ -44,5 +52,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
       - *install_aws_cli
       - *build_static_bundle
+      - *build_storybook
       - *deploy_to_non_prod
+      - *deploy_storybook_to_s3
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ out
 
 # terraform
 .terraform
+
+# storybook
+storybook-static

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ We are using [Storybook](https://storybook.js.org/) as a component documentation
 ```
 
 This command will start our documentation page after waiting 10 seconds.
+
+[Storybook Showcase](http://components.ucurtmaprojesi.com.s3-website.eu-west-2.amazonaws.com)
+[Non-production Environment](http://non-prod.ucurtmaprojesi.com.s3-website.eu-west-2.amazonaws.com)


### PR DESCRIPTION
There a few changes here;
1. Adds two new S3 bucket and user credentials for them
[Storybook Showcase](http://components.ucurtmaprojesi.com.s3-website.eu-west-2.amazonaws.com)
[Non-production Environment](http://non-prod.ucurtmaprojesi.com.s3-website.eu-west-2.amazonaws.com)
2. Updates circleci config to deploy the storybook to components bucket.

There will be a follow-up coming to delete the unused `non-prod-ucurtma-app` bucket after the first successful deployment to the new one.

The reason for the name change from `non-prod-ucurtma-app` to `non-prod.ucurtmaprojesi.com` is to make enable the Route53 alias forwarding.