### PR TITLE
Destroy the redundant s3 bucket for non-production

### DIFF
--- a/.aws/environments/non-prod/ucurtma-app-bucket.tf
+++ b/.aws/environments/non-prod/ucurtma-app-bucket.tf
@@ -1,16 +1,7 @@
-module "non-prod-app-deployment" {
-  source       = "../../modules/s3/web_hosting_s3_bucket"
-  bucket       = "non-prod-ucurtma-app"
-  region       = "eu-west-2"
-  remote_state = "${var.remote_state}"
-  web_page_user = "deployment-user"
-}
-
 module "non-prod-app-static-deployment" {
-  source       = "../../modules/s3/web_hosting_s3_bucket"
-  bucket       = "non-prod.ucurtmaprojesi.com"
-  region       = "eu-west-2"
-  remote_state = "${var.remote_state}"
+  source        = "../../modules/s3/web_hosting_s3_bucket"
+  bucket        = "non-prod.ucurtmaprojesi.com"
+  region        = "eu-west-2"
+  remote_state  = "${var.remote_state}"
   web_page_user = "non-prod-static-app-deployment-user"
 }
-


### PR DESCRIPTION
Destroys the resource by deleting the reference from the terraform file.