### PR TITLE
Patch Avatar

### DIFF
--- a/packages/frontend/components/ui/avatar.js
+++ b/packages/frontend/components/ui/avatar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cls from 'classnames';
 
-function Avatar({ type, className, image }) {
+function Avatar({ type, className, imagePath }) {
   const avatarType = {
     xs: 'w-8 h-8',
     normal: 'w-11 h-11',
@@ -17,10 +17,12 @@ function Avatar({ type, className, image }) {
         className
       )}
     >
-      {image ? (
-        <img
-          className="bg-no-repeat bg-center bg-contain"
-          src={image}
+      {imagePath ? (
+        <div
+          className="bg-no-repeat bg-center bg-cover w-full h-full"
+          style={{
+            backgroundImage: `url('${imagePath}')`,
+          }}
           alt="noopener norefferer"
         />
       ) : (
@@ -31,14 +33,14 @@ function Avatar({ type, className, image }) {
 }
 
 Avatar.defaultProps = {
-  image: '',
+  imagePath: '',
   type: 'normal',
   className: '',
 };
 
 Avatar.propTypes = {
   type: PropTypes.oneOf(['xs', 'normal', 'lg']),
-  image: PropTypes.string,
+  imagePath: PropTypes.string,
   className: PropTypes.string,
 };
 

--- a/packages/frontend/stories/avatar.stories.js
+++ b/packages/frontend/stories/avatar.stories.js
@@ -1,31 +1,20 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
+import { text, select } from '@storybook/addon-knobs';
 
 import { storiesOf } from '@storybook/react';
 import Avatar from '../components/ui/avatar';
 
 storiesOf('Avatar', module)
-  .add('Small Avatar', () => (
+  .add('Default Avatar', () => (
     <Avatar
       className={text('Classname')}
-      type="xs"
-      image="/img/placeholder-image-02.jpg"
-    />
-  ))
-  .add('Normal Avatar', () => (
-    <Avatar
-      className={text('Classname')}
-      type="normal"
-      image="/img/placeholder-image-02.jpg"
-    />
-  ))
-  .add('Large Avatar', () => (
-    <Avatar
-      className={text('Classname')}
-      type="lg"
-      image="/img/placeholder-image-02.jpg"
+      type={select('Type', ['xs', 'normal', 'lg'], 'normal')}
+      imagePath="/img/placeholder-image-02.jpg"
     />
   ))
   .add('Avatar without Image', () => (
-    <Avatar className={text('Classname')} type="lg" />
+    <Avatar
+      className={text('Classname')}
+      type={select('Type', ['xs', 'normal', 'lg'], 'normal')}
+    />
   ));


### PR DESCRIPTION
@omerozkilic there is some errors with Avatar component. Style properties like background-cover, background-repeat and background-position can not be used without background-image. You can't use them with `<img src="">` so I changed it with background-image.

Also, I changed image with imagePath. imagePath is more understandable. You can look changes in this PR.