### PR TITLE
add log in and sign up links to header

### DIFF
--- a/packages/frontend/__tests__/components/header.test.js
+++ b/packages/frontend/__tests__/components/header.test.js
@@ -8,4 +8,15 @@ describe('Header Tests', () => {
     const { container } = render(<Header />);
     expect(container.querySelector('#logo')).not.toBeNull();
   });
+
+  test('Show Navigation if showNav prop is provided', () => {
+    const { getByText } = render(<Header showNav />);
+    expect(getByText('Explore')).toBeInTheDocument();
+  });
+
+  test('Show User Avatar if User is logged in', () => {
+    const { getByTestId, queryByText } = render(<Header showNav loggedIn />);
+    expect(getByTestId('avatar')).toBeInTheDocument();
+    expect(queryByText('Log in')).not.toBeInTheDocument();
+  });
 });

--- a/packages/frontend/components/header.js
+++ b/packages/frontend/components/header.js
@@ -24,8 +24,18 @@ function Header({ loggedIn, showNav }) {
       },
     ],
     right: [
-      { color: 'paragraph', href: '/account/login', label: 'Log in' },
-      { color: 'linkBlue', href: '/account/signup', label: 'Start a campaign' },
+      {
+        color: 'paragraph',
+        href: '/account/login',
+        label: 'Log in',
+        condition: !loggedIn,
+      },
+      {
+        color: 'linkBlue',
+        href: '/account/signup',
+        label: 'Start a campaign',
+        condition: !loggedIn,
+      },
     ],
   };
   return (
@@ -67,7 +77,11 @@ function Header({ loggedIn, showNav }) {
               <>
                 <NavButton icon={Bell} label="Notifications" badge={1} />
                 {/* todo: get user from state management */}
-                <Avatar name="Ash Ketchum" src="broken-link" />
+                <Avatar
+                  data-testid="avatar"
+                  name="Ash Ketchum"
+                  src="broken-link"
+                />
               </>
             )}
           </Flex>

--- a/packages/frontend/components/header.js
+++ b/packages/frontend/components/header.js
@@ -13,10 +13,21 @@ const Logo = styled(Icon)`
 
 // todo: get loggedIn from token
 function Header({ loggedIn, showNav }) {
-  const navItems = [
-    { color: 'paragraph', href: '/', label: 'Explore' },
-    { color: 'linkBlue', href: '/', label: 'Start a campaign' },
-  ];
+  const navItems = {
+    left: [
+      { color: 'paragraph', href: '/', label: 'Explore' },
+      {
+        color: 'linkBlue',
+        href: '/',
+        label: 'Start a campaign',
+        condition: loggedIn,
+      },
+    ],
+    right: [
+      { color: 'paragraph', href: '/account/login', label: 'Log in' },
+      { color: 'linkBlue', href: '/account/signup', label: 'Start a campaign' },
+    ],
+  };
   return (
     <Container mt={4} display="block">
       <Flex justify="space-between" align="center">
@@ -28,20 +39,34 @@ function Header({ loggedIn, showNav }) {
         <Flex width="100%" justify="space-between" align="center">
           {showNav && (
             <Flex ml={12}>
-              {navItems.map((navItem, i) => (
-                <Link href={navItem.href} key={i.toString()}>
-                  <Button ml={4} color={navItem.color} variant="ghost">
-                    {navItem.label}
-                  </Button>
-                </Link>
-              ))}
+              {navItems.left.map(
+                (navItem, i) =>
+                  (navItem.condition || navItem.condition === undefined) && (
+                    <Link href={navItem.href} key={i.toString()}>
+                      <Button ml={4} color={navItem.color} variant="ghost">
+                        {navItem.label}
+                      </Button>
+                    </Link>
+                  )
+              )}
             </Flex>
           )}
           <Flex align="center">
             <NavButton icon={Search} label="Search" />
+            {navItems.right.map(
+              (navItem, i) =>
+                (navItem.condition || navItem.condition === undefined) && (
+                  <Link href={navItem.href} key={i.toString()}>
+                    <Button ml={4} color={navItem.color} variant="ghost">
+                      {navItem.label}
+                    </Button>
+                  </Link>
+                )
+            )}
             {loggedIn && (
               <>
                 <NavButton icon={Bell} label="Notifications" badge={1} />
+                {/* todo: get user from state management */}
                 <Avatar name="Ash Ketchum" src="broken-link" />
               </>
             )}


### PR DESCRIPTION
![resim](https://user-images.githubusercontent.com/11398393/69182387-f4f8e500-0b21-11ea-98e0-296e21630c9c.png)

log in and sign up pages will be accessible from header when you go to homepage with this pr.