### PR TITLE
File Upload changes

### DIFF
--- a/.aws/environments/non-prod/ucurtma-database.tf
+++ b/.aws/environments/non-prod/ucurtma-database.tf
@@ -13,7 +13,7 @@ module "non-prod-app-files-database-table" {
   namespace         = "uc"
   stage             = "non-prod"
   name              = "ucurtma-files-non-prod"
-  hash_key          = "userId"
+  hash_key          = "fileId"
   hash_key_type     = "S"
   enable_autoscaler = false
 }

--- a/packages/frontend/components/view/verification.js
+++ b/packages/frontend/components/view/verification.js
@@ -36,8 +36,8 @@ const verificationScheme = Yup.object().shape({
 });
 
 const UPLOAD_FILE = gql`
-  mutation uploadFile($type: FileType!, $file: Upload!) {
-    uploadFile(type: $type, file: $file) {
+  mutation uploadFile($type: FileType!, $file: Upload!, $userId: String!) {
+    uploadFile(type: $type, file: $file, userId: $userId) {
       fileId
       path
       type
@@ -70,7 +70,11 @@ function Verification() {
         onSubmit={async (values, { setSubmitting }) => {
           setSubmitting(true);
           await uploadFile({
-            variables: { type: 'PROOF_OF_EDUCATION', file: values.transcript },
+            variables: {
+              type: 'PROOF_OF_EDUCATION',
+              file: values.transcript,
+              userId: Math.floor(Math.random() * 100).toString(), // todo: get userID from db when it is ready
+            },
           });
         }}
       >


### PR DESCRIPTION
As a result of the backend changes, I've updated the query to accept `userId` as a parameter for `uploadFile` mutation. The changes in the `verification.js` is to satisfy this requirement. 

Also updated the files table with new `fileId` hash key. Using `userId` as the hash key was definitely a silly idea since one user can upload more than 1 document, therefore, the hash should be the `fileId` rather than the `userId`.